### PR TITLE
Added option for static-IP configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,15 @@ function WeMoAccessory(log, config) {
   this.service = config["service"] || "Switch";
   this.wemoName = config["wemo_name"] || this.name; // fallback to "name" if you didn't specify an exact "wemo_name"
   this.device = null; // instance of WeMo, for controlling the discovered device
-  this.log("Searching for WeMo device with exact name '" + this.wemoName + "'...");
-  this.search();
+
+  if(config["ip"]){
+    var port = config["port"] || 49153;
+    this.log("Adding WeMo device using static IP:PORT " + config["ip"] + ":" + port + "...");
+    this.device = new wemo(config["ip"], port);
+  } else {
+    this.log("Searching for WeMo device with exact name '" + this.wemoName + "'...");
+    this.search();
+  }
 }
 
 WeMoAccessory.prototype.search = function() {

--- a/sample-config.json
+++ b/sample-config.json
@@ -27,7 +27,8 @@
             "accessory": "WeMo",
             "name": "Bookcase Lamp",
             "description": "The Festoon Lights in the Back Yard.",
-            "wemo_name": "Bookcase Lamp"
+            "ip": "192.168.1.65",
+            "port": 49153,
         }
     ]
 }


### PR DESCRIPTION
Search was failing to discover WeMo devices on my network (IoT devices are on a separate subnet).  I've added the ability to specify an IP (and optional port) for a switch when configuring an accessory which works around the problem for me.